### PR TITLE
Name account directories by address

### DIFF
--- a/lib/genesis
+++ b/lib/genesis
@@ -47,10 +47,13 @@ do
   geth --datadir "$dbDir" --password "$accountDir/password" account new > "$accountDir/address";
 
   # Strip address from address file
-  address=$(cat "$accountDir/address" | grep -Eo "0x[0-9a-fA-F]+");
+  accountAddress=$(cat "$accountDir/address" | grep -Eo "0x[0-9a-fA-F]+");
 
-  echo ":::Successfully created address $address";
-  addresses="${addresses}$address ";
+  # Rename account directory to account address
+  mv $accountDir $accountsDir/$accountAddress;
+
+  echo ":::Successfully created address $accountAddress";
+  addresses="${addresses}$accountAddress ";
 
   i=$((i + 1));
 done


### PR DESCRIPTION
# Description

This keeps generated accounts within a directory that's named after the account's address. The reason for this change is to easily spot addresses from a quick look at the accounts directory without needing to first open up an account-n directory - where n is an integer.