### PR TITLE
Set Shell

### DIFF
--- a/lib/unlock-accounts
+++ b/lib/unlock-accounts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Check for geth
 test -x "$(command -v geth)" || {


### PR DESCRIPTION
# Description
 
Set shell for the `unlock-accounts` library to `sh`.
