### PR TITLE
Update Blockchain Details

### DIFF
--- a/lib/genesis
+++ b/lib/genesis
@@ -62,7 +62,7 @@ echo ":::Successfully set up new blockchain build artefacts.";
 
 echo ":::Generating the Genesis block file...";
 coinbase=$(echo "$addresses" | cut -d ' ' -f1);
-balance="0x666666666660000000000000000000000000000000000000000000000000000";
+balance="0x5A35A35A3";
 alloc="\"alloc\": {\n";
 j=1;
 for address in $addresses
@@ -99,7 +99,7 @@ cat <<AMY
   "coinbase": "$coinbase",
   "difficulty": "0x200",
   "extraData": "0x00",
-  "gasLimit":"0x535353",
+  "gasLimit":"0x5A33333",
   "nonce":"0x0000000000000042",
   "mixhash":
   "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/lib/start-network
+++ b/lib/start-network
@@ -23,7 +23,7 @@ etherbase=$(cat "$genesisConfig" | grep -Eo "\"coinbase\": \"0x[0-9a-fA-F]+\"" |
 
 startBlockchainNetworkNoUnlock () {
   # Start the blockchain network
-  geth --datadir "$dbDir" --networkid "666" --http --miner.gastarget "$targetGasLimit" --http.corsdomain "localhost:8545" --mine --miner.etherbase "$etherbase" --allow-insecure-unlock;
+  geth --datadir "$dbDir" --networkid "666" --http --miner.gastarget "$targetGasLimit" --http.corsdomain "localhost:8545" --mine --miner.etherbase "$etherbase" --miner.threads 1 --allow-insecure-unlock;
 }
 
 if [[ $# -gt 0 ]]

--- a/lib/unlock-accounts
+++ b/lib/unlock-accounts
@@ -65,7 +65,7 @@ unlockAccounts () {
       etherbase=$(cat "${genesisConfig}" | grep -Eo "\"coinbase\": \"0x[0-9a-fA-F]+\"" | cut -d " " -f2 | cut -d "\"" -f2);
 
       echo "Unlocking accounts: ${1} and starting the network ..."
-      geth --datadir "$dbDir" --networkid "666" --http --http.corsdomain "localhost:8545" --unlock "${1}" --password "${passwordsFile}" --allow-insecure-unlock --miner.gastarget "${targetGasLimit}" --mine --miner.etherbase "${etherbase}";
+      geth --datadir "$dbDir" --networkid "666" --http --http.corsdomain "localhost:8545" --unlock "${1}" --password "${passwordsFile}" --allow-insecure-unlock --miner.gastarget "${targetGasLimit}" --mine --miner.etherbase "${etherbase}" --miner.threads 1;
     else
       echo "Unlocking accounts: ${1}"
       geth --datadir "$dbDir" --networkid "666" --http --http.corsdomain "localhost:8545" --unlock "${1}" --password "${passwordsFile}" --allow-insecure-unlock;


### PR DESCRIPTION
# Description

To enable mining immediately after starting the network, the `--miner.threads` option has been set to 1. Also, the default balance of accounts in the genesis has been reduced to below the miner's gas target.